### PR TITLE
[RC-342] Cards from JSON

### DIFF
--- a/src/components/Viewer/Viewer.js
+++ b/src/components/Viewer/Viewer.js
@@ -127,8 +127,6 @@ const Viewer = () => {
                             className={classes.jsonCard}
                             variant='outlined'
                         >
-                            {console.log(index)}
-                            {console.log(card)}
                             <CardContent>
                                 {Object.entries(card).map((row, indexrow) => (
                                     <Typography

--- a/src/components/Viewer/Viewer.js
+++ b/src/components/Viewer/Viewer.js
@@ -44,9 +44,10 @@ export const useStyles = makeStyles(() => ({
         margin: 10,
         minWidth: 450,
         display: 'flex',
-        flexDirection: 'row',
         flexWrap: 'wrap',
+        flexDirection: 'row',
         justifyContent: 'center',
+        alignContent: 'flex-start',
         overflow: 'auto',
     },
     buttonLoad: {
@@ -72,11 +73,14 @@ export const useStyles = makeStyles(() => ({
         right: 0,
     },
     jsonCard: {
-        minHeight: 40,
-        width: 170,
+        minWidth: 180,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
         margin: 10,
-        height: 'fit-content',
         cursor: 'pointer',
+        border: '1px solid white',
     },
 }));
 
@@ -125,7 +129,6 @@ const Viewer = () => {
                         <Card
                             key={index}
                             className={classes.jsonCard}
-                            variant='outlined'
                         >
                             <CardContent>
                                 {Object.entries(card).map((row, indexrow) => (
@@ -133,12 +136,30 @@ const Viewer = () => {
                                         key={indexrow}
                                         variant='body2'
                                     >
-                                        {`${row[0]}: ${row[1]}`}
+                                        <b>{row[0]}</b>
+                                        {`: ${row[1]}`}
                                     </Typography>
                                 ))}
                             </CardContent>
                         </Card>
                     ))}
+                    {selection && !Array.isArray(json[selection]) && (
+                        <Card
+                            className={classes.jsonCard}
+                        >
+                            <CardContent>
+                                {Object.entries(json[selection]).map((row, indexrow) => (
+                                    <Typography
+                                        key={indexrow}
+                                        variant='body2'
+                                    >
+                                        <b>{row[0]}</b>
+                                        {`: ${row[1]}`}
+                                    </Typography>
+                                ))}
+                            </CardContent>
+                        </Card>
+                    )}
                 </Box>
 
                 <FileUploader

--- a/src/components/Viewer/Viewer.js
+++ b/src/components/Viewer/Viewer.js
@@ -6,6 +6,9 @@ import GetAppIcon from '@material-ui/icons/GetApp';
 import ReplayIcon from '@material-ui/icons/Replay';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import Typography from '@material-ui/core/Typography';
 import FileUploader from '../FileUploader';
 import Button from '../Button';
 
@@ -34,6 +37,18 @@ export const useStyles = makeStyles(() => ({
         margin: 10,
         minWidth: 450,
     },
+    containerCards: {
+        position: 'relative',
+        height: '86%',
+        width: '98%',
+        margin: 10,
+        minWidth: 450,
+        display: 'flex',
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        justifyContent: 'center',
+        overflow: 'auto',
+    },
     buttonLoad: {
         position: 'absolute',
         bottom: 0,
@@ -56,12 +71,19 @@ export const useStyles = makeStyles(() => ({
         top: 3,
         right: 0,
     },
+    jsonCard: {
+        minHeight: 40,
+        width: 170,
+        margin: 10,
+        height: 'fit-content',
+        cursor: 'pointer',
+    },
 }));
 
 const Viewer = () => {
     const classes = useStyles();
     const [json, setJson] = useState();
-    const [, setSelection] = useState('');
+    const [selection, setSelection] = useState('');
 
     const handleChange = event => {
         const sel = event.target.value;
@@ -96,6 +118,30 @@ const Viewer = () => {
                         </MenuItem>
                     ))}
                 </Select>
+                <Box
+                    className={classes.containerCards}
+                >
+                    {selection && Array.isArray(json[selection]) && json[selection].map((card, index) => (
+                        <Card
+                            key={index}
+                            className={classes.jsonCard}
+                            variant='outlined'
+                        >
+                            {console.log(index)}
+                            {console.log(card)}
+                            <CardContent>
+                                {Object.entries(card).map((row, indexrow) => (
+                                    <Typography
+                                        key={indexrow}
+                                        variant='body2'
+                                    >
+                                        {`${row[0]}: ${row[1]}`}
+                                    </Typography>
+                                ))}
+                            </CardContent>
+                        </Card>
+                    ))}
+                </Box>
 
                 <FileUploader
                     acceptedFiles={[


### PR DESCRIPTION

![94288B47-DB2B-497F-9F3A-C957C19EA6C5](https://user-images.githubusercontent.com/72103416/116616597-de57df80-a90a-11eb-856b-c15174e5f3c7.jpeg)
Show all cards related to the selected picklist value
Hovering on the card should show a different cursor
The card should clearly show all the attribute and values of the selected object. For example if the object looks like this:
``` { "name": "TOP", "type": "coupled" }
```
Then the card shows:

Name: Top
Type: Coupled